### PR TITLE
Default to Postgresql instead of H2

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,12 +28,12 @@ spring:
       connectionTimeout: 172800000
       idleTimeout: 3600000
       maximumPoolSize: 16
-    platform: h2
-    url: jdbc:h2:./target/mod-data-migration;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driverClassName: org.h2.Driver
-    # platform: postgres
-    # driverClassName: org.postgresql.Driver
-    # url: jdbc:postgresql://localhost:5432/mod-data-migration
+    # platform: h2
+    # url: jdbc:h2:./target/mod-data-migration;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    # driverClassName: org.h2.Driver
+    platform: postgres
+    driverClassName: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/mod-data-migration
 
     username: folio
     password: folio
@@ -49,15 +49,15 @@ spring:
       settings:
         web-allow-others: false
   jpa:
-    database-platform: org.folio.rest.dialect.CustomH2Dialect
-    # database-platform: org.folio.rest.dialect.CustomPostgreSQLDialect
+    # database-platform: org.folio.rest.dialect.CustomH2Dialect
+    database-platform: org.folio.rest.dialect.CustomPostgreSQLDialect
 
     properties:
       hibernate:
         order_inserts: true
         order_updates: true
-        dialect: org.folio.rest.dialect.CustomH2Dialect
-        # dialect: org.folio.rest.dialect.CustomPostgreSQLDialect
+        # dialect: org.folio.rest.dialect.CustomH2Dialect
+        dialect: org.folio.rest.dialect.CustomPostgreSQLDialect
         jdbc:
           batch_size: 100
           lob.non_contextual_creation: true


### PR DESCRIPTION
This module utilizes the Postgresql-specific **COPY** operation.
Therefore H2 cannot be supported and must not be defaulted to.