### PR TITLE
Issue 28: update hrid start number after migration completes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,76 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Build a VM to serve as an Okapi/Docker server
+# Deploy development environment
+
+def frontend_port_mapping(config)
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+end
+
+def backend_port_mapping(config)
+  # config.vm.network "forwarded_port", guest: 8000, host: 8130
+  config.vm.network "forwarded_port", guest: 5432, host: 5433
+  config.vm.network "forwarded_port", guest: 9130, host: 9130
+end
+
+Vagrant.configure(2) do |config|
+
+  # Install vagrant-disksize to allow resizing the vagrant box disk.
+  unless Vagrant.has_plugin?("vagrant-disksize")
+    raise  Vagrant::Errors::VagrantError.new, "vagrant-disksize plugin is missing. Please install it using 'vagrant plugin install vagrant-disksize' and rerun 'vagrant up'"
+  end
+  
+  config.disksize.size = "200GB"
+
+  # Give us a little headroom
+  # Note that provisioning a Stripes webpack requires more RAM
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 16384
+    vb.cpus = 6
+  end
+
+  # https://app.vagrantup.com/folio/boxes/snapshot-backend-core
+  config.vm.define "snapshot-backend-core", autostart: false do |snapshot_backend_core|
+    snapshot_backend_core.vm.box = "folio/snapshot-backend-core"
+    backend_port_mapping(snapshot_backend_core)
+  end
+
+  # https://app.vagrantup.com/folio/boxes/snapshot-core
+  config.vm.define "snapshot-core", autostart: false do |snapshot_core|
+    snapshot_core.vm.box = "folio/snapshot-core"
+    frontend_port_mapping(snapshot_core)
+    backend_port_mapping(snapshot_core)
+  end
+
+  # https://app.vagrantup.com/folio/boxes/snapshot
+  config.vm.define "snapshot", autostart: false do |snapshot|
+    snapshot.vm.box = "folio/snapshot"
+    frontend_port_mapping(snapshot)
+    backend_port_mapping(snapshot)
+  end
+
+  # https://app.vagrantup.com/folio/boxes/testing-backend
+  config.vm.define "testing-backend", autostart: false do |testing_backend|
+    testing_backend.vm.box = "folio/testing-backend"
+    backend_port_mapping(testing_backend)
+  end
+
+  # https://app.vagrantup.com/folio/boxes/testing
+  config.vm.define "testing", autostart: false do |testing|
+    testing.vm.box = "folio/testing"
+    frontend_port_mapping(testing)
+    backend_port_mapping(testing)
+  end
+
+  # https://app.vagrantup.com/folio/boxes/release
+  config.vm.define "release", autostart: false do |release|
+    release.vm.box = "folio/release"
+    frontend_port_mapping(release)
+    backend_port_mapping(release)
+  end
+
+  if Vagrant::Util::Platform.windows?
+    config.vm.synced_folder ".", "/vagrant", disabled: "true"
+  end
+
+end

--- a/src/main/java/org/folio/rest/migration/AbstractMigration.java
+++ b/src/main/java/org/folio/rest/migration/AbstractMigration.java
@@ -50,6 +50,9 @@ public abstract class AbstractMigration<C extends AbstractContext> implements Mi
   static final String INDEX = "INDEX";
   static final String TOTAL = "TOTAL";
 
+  static final String PREFIX = "prefix";
+  static final String START_NUMBER = "startNumber";
+
   static final String NULL = "null";
 
   static final String HRID_TEMPLATE = "%s%011d";

--- a/src/main/java/org/folio/rest/migration/BibMigration.java
+++ b/src/main/java/org/folio/rest/migration/BibMigration.java
@@ -121,6 +121,8 @@ public class BibMigration extends AbstractMigration<BibContext> {
 
       @Override
       public void complete() {
+        migrationService.okapiService.updateHridSettings(tenant, token, hridSettings);
+        log.info("updated hrid settings: {}", hridSettings);
         postActions(folioSettings, context.getPostActions());
       }
 
@@ -130,8 +132,8 @@ public class BibMigration extends AbstractMigration<BibContext> {
     countContext.put(SQL, context.getExtraction().getCountSql());
 
     JsonObject instancesHridSettings = hridSettings.getJsonObject("instances");
-    String hridPrefix = instancesHridSettings.getString("prefix");
-    int originalHridStartNumber = instancesHridSettings.getInteger("startNumber");
+    String hridPrefix = instancesHridSettings.getString(PREFIX);
+    int originalHridStartNumber = instancesHridSettings.getInteger(START_NUMBER);
 
     int hridStartNumber = originalHridStartNumber;
 
@@ -167,13 +169,15 @@ public class BibMigration extends AbstractMigration<BibContext> {
         taskQueue.submit(new BibPartitionTask(migrationService, instanceMapper, partitionContext));
         offset += limit;
         index++;
-        if (i < partitions) {
+        if (i < partitions - 1) {
           hridStartNumber += limit;
         } else {
           hridStartNumber = originalHridStartNumber + count;
         }
       }
     }
+
+    instancesHridSettings.put(START_NUMBER, ++hridStartNumber);
 
     return CompletableFuture.completedFuture(true);
   }

--- a/src/main/java/org/folio/rest/migration/aspect/ReferenceDataAspect.java
+++ b/src/main/java/org/folio/rest/migration/aspect/ReferenceDataAspect.java
@@ -90,7 +90,7 @@ public class ReferenceDataAspect {
   }
 
   private void createReferenceData(ReferenceData referenceData) {
-    referenceData.getData().forEach(data -> {
+    for(JsonNode data : referenceData.getData()) {
       ReferenceDatum datum = ReferenceDatum.of(referenceData, data);
       try {
         JsonNode rd = okapiService.createReferenceData(datum);
@@ -98,7 +98,7 @@ public class ReferenceDataAspect {
       } catch (Exception e) {
         logger.debug("failed creating reference data {} {}", referenceData.getName(), data);
       }
-    });
+    }
   }
 
 }

--- a/src/main/java/org/folio/rest/migration/service/OkapiService.java
+++ b/src/main/java/org/folio/rest/migration/service/OkapiService.java
@@ -45,6 +45,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import io.vertx.core.json.JsonObject;
@@ -126,6 +127,18 @@ public class OkapiService {
       return new JsonObject(response.getBody());
     }
     throw new RuntimeException("Failed to fetch rules: " + response.getStatusCodeValue());
+  }
+
+  public void updateHridSettings(String tenant, String token, JsonObject hridSettings) {
+    long startTime = System.nanoTime();
+    HttpEntity<?> entity = new HttpEntity<>(hridSettings.getMap(), headers(tenant, token));
+    String url = okapi.getUrl() + "/hrid-settings-storage/hrid-settings";
+    try {
+      restTemplate.put(url, entity);
+      log.debug("update hrid settings: {} milliseconds", TimingUtility.getDeltaInMilliseconds(startTime));
+    } catch (RestClientException e) {
+      throw new RuntimeException("Failed to update hrid settings: " + e.getMessage());  
+    }
   }
 
   // TODO: get JsonSchema for hrid-settings


### PR DESCRIPTION
applicable to instances, holdings, and items

Resolves #28 

Added unrelated Vagrantfile to bring up folio/release vm for local development and testing migrations. It was moved over from `fm-cli` now that the cli is not needed anymore.