### PR TITLE
create copy holdings record for child instance that does not have one

### DIFF
--- a/src/main/java/org/folio/rest/migration/BoundWithMigration.java
+++ b/src/main/java/org/folio/rest/migration/BoundWithMigration.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.rest.jaxrs.model.inventory.Holdingsrecord;

--- a/src/main/java/org/folio/rest/migration/BoundWithMigration.java
+++ b/src/main/java/org/folio/rest/migration/BoundWithMigration.java
@@ -182,15 +182,8 @@ public class BoundWithMigration extends AbstractMigration<BoundWithContext> {
           }
 
           for (ReferenceLink instanceRL : instanceRLs) {
-            Holdingsrecords holdingsRecords = migrationService.okapiService.fetchHoldingsRecordsByInstanceId(tenant, token, instanceRL.getFolioReference());
-            boolean hasExistingHoldingsRecord = false;
-            for (Holdingsrecord childHoldingsRecord : holdingsRecords.getHoldingsRecords()) {
-              if (childHoldingsRecord.getId().equals(existingHoldingsRecord.getId())) {
-                hasExistingHoldingsRecord = true;
-                break;
-              }
-            }
-            if (!hasExistingHoldingsRecord) {
+            Holdingsrecords holdingsRecords = migrationService.okapiService.fetchHoldingsRecordsByIdAndInstanceId(tenant, token, existingHoldingsRecordId, instanceRL.getFolioReference());
+            if (holdingsRecords.getTotalRecords() == 0) {
               Holdingsrecord childHoldingsRecord = existingHoldingsRecord;
               String bibId = instanceRL.getExternalReference();
               childHoldingsRecord.setId(craftUUID("bound-with-child-holdings-record", schema, mfhdId + ":" + bibId));

--- a/src/main/java/org/folio/rest/migration/service/OkapiService.java
+++ b/src/main/java/org/folio/rest/migration/service/OkapiService.java
@@ -401,10 +401,10 @@ public class OkapiService {
     throw new RuntimeException("Failed to fetch loan types: " + response.getStatusCodeValue());
   }
 
-  public Holdingsrecords fetchHoldingsRecordsByInstanceId(String tenant, String token, String instanceId) {
+  public Holdingsrecords fetchHoldingsRecordsByIdAndInstanceId(String tenant, String token, String id, String instanceId) {
     long startTime = System.nanoTime();
     HttpEntity<?> entity = new HttpEntity<>(headers(tenant, token));
-    String url = okapi.getUrl() + "/holdings-storage/holdings?query=instanceId==" + instanceId;
+    String url = okapi.getUrl() + "/holdings-storage/holdings?query=(id==" + id + " AND instanceId==" + instanceId + ")";
     ResponseEntity<Holdingsrecords> response = restTemplate.exchange(url, HttpMethod.GET, entity, Holdingsrecords.class);
     log.debug("fetch item records: {} milliseconds", TimingUtility.getDeltaInMilliseconds(startTime));
     if (response.getStatusCodeValue() == 200) {

--- a/src/main/java/org/folio/rest/migration/service/OkapiService.java
+++ b/src/main/java/org/folio/rest/migration/service/OkapiService.java
@@ -32,6 +32,7 @@ import org.folio.rest.jaxrs.model.dataimport.mod_data_import_converter_storage.J
 import org.folio.rest.jaxrs.model.dataimport.mod_data_import_converter_storage.JobProfileCollection;
 import org.folio.rest.jaxrs.model.dataimport.mod_data_import_converter_storage.JobProfileUpdateDto;
 import org.folio.rest.jaxrs.model.inventory.Holdingsrecord;
+import org.folio.rest.jaxrs.model.inventory.Holdingsrecords;
 import org.folio.rest.jaxrs.model.inventory.Instance;
 import org.folio.rest.jaxrs.model.inventory.Instancerelationship;
 import org.folio.rest.jaxrs.model.inventory.Item;
@@ -398,6 +399,19 @@ public class OkapiService {
     }
     log.error("Failed to fetch loan types: " + response.getStatusCodeValue());
     throw new RuntimeException("Failed to fetch loan types: " + response.getStatusCodeValue());
+  }
+
+  public Holdingsrecords fetchHoldingsRecordsByInstanceId(String tenant, String token, String instanceId) {
+    long startTime = System.nanoTime();
+    HttpEntity<?> entity = new HttpEntity<>(headers(tenant, token));
+    String url = okapi.getUrl() + "/holdings-storage/holdings?query=instanceId==" + instanceId;
+    ResponseEntity<Holdingsrecords> response = restTemplate.exchange(url, HttpMethod.GET, entity, Holdingsrecords.class);
+    log.debug("fetch item records: {} milliseconds", TimingUtility.getDeltaInMilliseconds(startTime));
+    if (response.getStatusCodeValue() == 200) {
+      return response.getBody();
+    }
+    log.error("Failed to fetch holdings records: " + response.getStatusCodeValue());
+    throw new RuntimeException("Failed to fetch holdings records: " + response.getStatusCodeValue());
   }
 
   public Items fetchItemRecordsByHoldingsRecordId(String tenant, String token, String holdingsRecordId) {


### PR DESCRIPTION
resolves #184 

This PR ensures all children instances of a bound with instance have the appropriate holdings record. One child instance will already have the holdings record from the holdings record migration. To accomplish, a request to FOLIO to check if the child instance has the bound with holdings record. If not, create clone holdings record on the child instance.