### PR TITLE
Issue 269: Add exclusion by column in bib and holdings migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,9 @@ POST to http://localhost:9000/migrate/bibs
       "references": {
         "sourceRecordTypeId": "96017110-47c5-4d55-8324-7dab1771749b",
         "instanceTypeId": "43efa217-2d57-4d75-82ef-4372507d0672"
+      },
+      "exclusions": {
+        "OPERATOR_ID": ["olibrary"]
       }
     },
     {
@@ -683,6 +686,9 @@ POST to http://localhost:9000/migrate/bibs
       "references": {
         "sourceRecordTypeId": "b9f633b3-22e4-4bad-8785-da09d9eaa6c8",
         "instanceTypeId": "fb6db4f0-e5c3-483b-a1da-3edbb96dc8e8"
+      },
+      "exclusions": {
+        "OPERATOR_ID": ["olibrary"]
       }
     }
   ],
@@ -727,6 +733,9 @@ POST to http://localhost:9000/migrate/holdings
         "holdingToBibTypeId": "0ff1680d-caf5-4977-a78f-2a4fd64a2cdc",
         "holdingToCallNumberPrefixTypeId": "bdc5c8b1-7b21-45ea-943b-585764f3715c",
         "holdingToCallNumberSuffixTypeId": "fcd2963b-b75d-4401-8eda-7e91efd8ddc3"
+      },
+      "exclusions": {
+        "OPERATOR_ID": ["olibrary"]
       }
     },
     {
@@ -738,6 +747,9 @@ POST to http://localhost:9000/migrate/holdings
         "holdingToBibTypeId": "f8252895-6bf5-4458-8a3f-57bd8c36c6ba",
         "holdingToCallNumberPrefixTypeId": "78991218-9141-4807-9175-7147c861a596",
         "holdingToCallNumberSuffixTypeId": "be7288c9-7c67-4b6b-b662-a57816569e46"
+      },
+      "exclusions": {
+        "OPERATOR_ID": ["olibrary"]
       }
     }
   ],

--- a/src/main/java/org/folio/rest/migration/AbstractMigration.java
+++ b/src/main/java/org/folio/rest/migration/AbstractMigration.java
@@ -135,6 +135,17 @@ public abstract class AbstractMigration<C extends AbstractContext> implements Mi
     return sub.replace(template);
   }
 
+  boolean exclude(Map<String, List<String>> exclusions, ResultSet pageResultSet) throws SQLException {
+    for (Map.Entry<String, List<String>> entry : exclusions.entrySet()) {
+      String column = entry.getKey();
+      String value = pageResultSet.getString(column);
+      if (entry.getValue().contains(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   String getMarc(Statement statement, Map<String, Object> context) throws SQLException, IOException {
     try (ResultSet resultSet = getResultSet(statement, context)) {
       List<SequencedMarc> marcSequence = new ArrayList<>();

--- a/src/main/java/org/folio/rest/migration/BibMigration.java
+++ b/src/main/java/org/folio/rest/migration/BibMigration.java
@@ -295,6 +295,10 @@ public class BibMigration extends AbstractMigration<BibContext> {
           String suppressInOpac = pageResultSet.getString(SUPPRESS_IN_OPAC);
           String operatorId = pageResultSet.getString(OPERATOR_ID);
 
+          if (exclude(job.getExclusions(), pageResultSet)) {
+            continue;
+          }
+
           Boolean suppressDiscovery = suppressInOpac.equals("Y");
 
           marcContext.put(BIB_ID, bibId);

--- a/src/main/java/org/folio/rest/migration/HoldingsMigration.java
+++ b/src/main/java/org/folio/rest/migration/HoldingsMigration.java
@@ -10,6 +10,7 @@ import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -258,6 +259,10 @@ public class HoldingsMigration extends AbstractMigration<HoldingsContext> {
           String receiptStatusCode = pageResultSet.getString(RECEIPT_STATUS);
           String acqMethodCode = pageResultSet.getString(ACQ_METHOD);
           String retentionCode = pageResultSet.getString(RETENTION);
+
+          if (exclude(job.getExclusions(), pageResultSet)) {
+            continue;
+          }
 
           marcContext.put(MFHD_ID, mfhdId);
 

--- a/src/main/java/org/folio/rest/migration/model/request/bib/BibJob.java
+++ b/src/main/java/org/folio/rest/migration/model/request/bib/BibJob.java
@@ -1,6 +1,7 @@
 package org.folio.rest.migration.model.request.bib;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.validation.constraints.NotNull;
@@ -24,9 +25,12 @@ public class BibJob extends AbstractJob {
 
   private Map<String, String> references;
 
+  private Map<String, List<String>> exclusions;
+
   public BibJob() {
     super();
-    references = new HashMap<String, String>();
+    references = new HashMap<>();
+    exclusions = new HashMap<>();
   }
 
   public String getUser() {
@@ -67,6 +71,14 @@ public class BibJob extends AbstractJob {
 
   public void setReferences(Map<String, String> references) {
     this.references = references;
+  }
+
+  public Map<String, List<String>> getExclusions() {
+    return exclusions;
+  }
+
+  public void setExclusions(Map<String, List<String>> exclusions) {
+    this.exclusions = exclusions;
   }
 
 }

--- a/src/main/java/org/folio/rest/migration/model/request/boundwith/BoundWithJob.java
+++ b/src/main/java/org/folio/rest/migration/model/request/boundwith/BoundWithJob.java
@@ -28,7 +28,7 @@ public class BoundWithJob extends AbstractJob {
 
   public BoundWithJob() {
     super();
-    references = new HashMap<String, String>();
+    references = new HashMap<>();
   }
 
   public Map<String, String> getReferences() {

--- a/src/main/java/org/folio/rest/migration/model/request/holdings/HoldingsJob.java
+++ b/src/main/java/org/folio/rest/migration/model/request/holdings/HoldingsJob.java
@@ -19,7 +19,7 @@ public class HoldingsJob extends AbstractJob {
 
   public HoldingsJob() {
     super();
-    references = new HashMap<String, String>();
+    references = new HashMap<>();
     exclusions = new HashMap<>();
   }
 

--- a/src/main/java/org/folio/rest/migration/model/request/holdings/HoldingsJob.java
+++ b/src/main/java/org/folio/rest/migration/model/request/holdings/HoldingsJob.java
@@ -1,6 +1,7 @@
 package org.folio.rest.migration.model.request.holdings;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.validation.constraints.NotNull;
@@ -14,9 +15,12 @@ public class HoldingsJob extends AbstractJob {
 
   private Map<String, String> references;
 
+  private Map<String, List<String>> exclusions;
+
   public HoldingsJob() {
     super();
     references = new HashMap<String, String>();
+    exclusions = new HashMap<>();
   }
 
   public String getUser() {
@@ -33,6 +37,14 @@ public class HoldingsJob extends AbstractJob {
 
   public void setReferences(Map<String, String> references) {
     this.references = references;
+  }
+
+  public Map<String, List<String>> getExclusions() {
+    return exclusions;
+  }
+
+  public void setExclusions(Map<String, List<String>> exclusions) {
+    this.exclusions = exclusions;
   }
 
 }

--- a/src/main/java/org/folio/rest/migration/model/request/inventory/InventoryReferenceLinkJob.java
+++ b/src/main/java/org/folio/rest/migration/model/request/inventory/InventoryReferenceLinkJob.java
@@ -11,7 +11,7 @@ public class InventoryReferenceLinkJob extends AbstractJob {
 
   public InventoryReferenceLinkJob() {
     super();
-    references = new HashMap<String, String>();
+    references = new HashMap<>();
   }
 
   public Map<String, String> getReferences() {

--- a/src/main/java/org/folio/rest/migration/model/request/user/UserReferenceLinkJob.java
+++ b/src/main/java/org/folio/rest/migration/model/request/user/UserReferenceLinkJob.java
@@ -16,7 +16,7 @@ public class UserReferenceLinkJob extends AbstractJob {
 
   public UserReferenceLinkJob() {
     super();
-    references = new HashMap<String, String>();
+    references = new HashMap<>();
   }
 
   public String getDecodeSql() {

--- a/src/main/java/org/folio/rest/migration/model/request/vendor/VendorMaps.java
+++ b/src/main/java/org/folio/rest/migration/model/request/vendor/VendorMaps.java
@@ -17,9 +17,9 @@ public class VendorMaps {
   private Map<String, String> vendorTypes;
 
   public VendorMaps() {
-    categories = new HashMap<String, String>();
-    countryCodes = new HashMap<String, String>();
-    vendorTypes = new HashMap<String, String>();
+    categories = new HashMap<>();
+    countryCodes = new HashMap<>();
+    vendorTypes = new HashMap<>();
   }
 
   public Map<String, String> getCategories() {


### PR DESCRIPTION
Used to exclude operator id of olibrary. Would have liked to adjust the page and select query but is not trivial due to the optimizations in the page query. This is a configurable exclusion that can be used on arbitrary columns.

Bib count query:

```
SELECT COUNT(*) AS total FROM ${SCHEMA}.bib_master;
```

Bib page query:

```
WITH bibs AS (
    SELECT
      bib_id,
      suppress_in_opac
    FROM ${SCHEMA}.bib_master
    ORDER BY bib_id OFFSET ${OFFSET} ROWS FETCH NEXT ${LIMIT} ROWS ONLY
),
operators AS (
    SELECT
      bib_id,
      operator_id
    FROM ${SCHEMA}.bib_history
    WHERE action_type_id = 1
      AND bib_id IN (SELECT bib_id FROM bibs)
)
SELECT
  b.bib_id,
  b.suppress_in_opac,
  o.operator_id
FROM bibs b
LEFT JOIN operators o ON b.bib_id = o.bib_id;
```

Holdings count query:

```
SELECT COUNT(*) AS total FROM ${SCHEMA}.mfhd_master
```

Holdings page query:

```
WITH holdings AS (
    SELECT 
      mfhd_id,
      suppress_in_opac,
      location_id,
      display_call_no,
      call_no_type,
      record_type,
      field_008
    FROM ${SCHEMA}.mfhd_master
    ORDER BY mfhd_id OFFSET ${OFFSET} ROWS FETCH NEXT ${LIMIT} ROWS ONLY
),
operators AS (
    SELECT
      mfhd_id,
      operator_id
    FROM ${SCHEMA}.mfhd_history
    WHERE action_type_id = 1
      AND mfhd_id IN (SELECT mfhd_id FROM holdings)
)
SELECT
  h.mfhd_id,
  h.suppress_in_opac,
  h.location_id,
  h.display_call_no,
  h.call_no_type,
  h.record_type,
  substr(h.field_008, 7, 1) AS receipt_status,
  substr(h.field_008, 8, 1) AS acq_method,
  substr(h.field_008, 13, 1) AS retention,
  o.operator_id
FROM holdings h
LEFT JOIN operators o ON h.mfhd_id = o.mfhd_id;
```