### PR TITLE
Issue 272: Pass call number from holdings migration to items migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,6 +731,7 @@ POST to http://localhost:9000/migrate/holdings
       "references": {
         "holdingTypeId": "67c65ccb-02b1-4f15-8278-eb5b029cdcd5",
         "holdingToBibTypeId": "0ff1680d-caf5-4977-a78f-2a4fd64a2cdc",
+        "holdingToCallNumberTypeId": "0d9b3c6e-e486-4e8f-97c8-60995d46cfce",
         "holdingToCallNumberPrefixTypeId": "bdc5c8b1-7b21-45ea-943b-585764f3715c",
         "holdingToCallNumberSuffixTypeId": "fcd2963b-b75d-4401-8eda-7e91efd8ddc3"
       },
@@ -745,6 +746,7 @@ POST to http://localhost:9000/migrate/holdings
       "references": {
         "holdingTypeId": "e7fbdcf5-8fb0-417e-b477-6ee9d6832f12",
         "holdingToBibTypeId": "f8252895-6bf5-4458-8a3f-57bd8c36c6ba",
+        "holdingToCallNumberTypeId": "2237564d-30f2-4529-9320-374221af44f1",
         "holdingToCallNumberPrefixTypeId": "78991218-9141-4807-9175-7147c861a596",
         "holdingToCallNumberSuffixTypeId": "be7288c9-7c67-4b6b-b662-a57816569e46"
       },
@@ -918,6 +920,7 @@ POST to http://localhost:9000/migrate/items
       "references": {
         "itemTypeId": "53e72510-dc82-4caa-a272-1522cca70bc2",
         "itemToHoldingTypeId": "39670cf7-de23-4473-b5e3-abf6d79735e1",
+        "holdingToCallNumberTypeId": "0d9b3c6e-e486-4e8f-97c8-60995d46cfce",
         "holdingToCallNumberPrefixTypeId": "bdc5c8b1-7b21-45ea-943b-585764f3715c",
         "holdingToCallNumberSuffixTypeId": "fcd2963b-b75d-4401-8eda-7e91efd8ddc3"
       }
@@ -931,6 +934,7 @@ POST to http://localhost:9000/migrate/items
       "references": {
         "itemTypeId": "0014559d-39f6-45c7-9406-03643459aaf0",
         "itemToHoldingTypeId": "492fea54-399a-4822-8d4b-242096c2ab12",
+        "holdingToCallNumberTypeId": "2237564d-30f2-4529-9320-374221af44f1",
         "holdingToCallNumberPrefixTypeId": "78991218-9141-4807-9175-7147c861a596",
         "holdingToCallNumberSuffixTypeId": "be7288c9-7c67-4b6b-b662-a57816569e46"
       }

--- a/src/main/java/org/folio/rest/migration/ItemMigration.java
+++ b/src/main/java/org/folio/rest/migration/ItemMigration.java
@@ -105,6 +105,7 @@ public class ItemMigration extends AbstractMigration<ItemContext> {
   private static final String ITEM_REFERENCE_ID = "itemTypeId";
   private static final String ITEM_TO_HOLDING_REFERENCE_ID = "itemToHoldingTypeId";
 
+  private static final String HOLDING_TO_CALL_NUMBER_ID = "holdingToCallNumberTypeId";
   private static final String HOLDING_TO_CALL_NUMBER_PREFIX_ID = "holdingToCallNumberPrefixTypeId";
   private static final String HOLDING_TO_CALL_NUMBER_SUFFIX_ID = "holdingToCallNumberSuffixTypeId";
 
@@ -282,6 +283,7 @@ public class ItemMigration extends AbstractMigration<ItemContext> {
       String itemRLTypeId = job.getReferences().get(ITEM_REFERENCE_ID);
       String itemToHoldingRLTypeId = job.getReferences().get(ITEM_TO_HOLDING_REFERENCE_ID);
 
+      String holdingToCallNumberTypeId = job.getReferences().get(HOLDING_TO_CALL_NUMBER_ID);
       String holdingToCallNumberPrefixTypeId = job.getReferences().get(HOLDING_TO_CALL_NUMBER_PREFIX_ID);
       String holdingToCallNumberSuffixTypeId = job.getReferences().get(HOLDING_TO_CALL_NUMBER_SUFFIX_ID);
 
@@ -393,6 +395,12 @@ public class ItemMigration extends AbstractMigration<ItemContext> {
             if (locationsMap.containsKey(voyagerPermLocationId)) {
               itemRecord.setEffectiveLocationId(locationsMap.get(voyagerPermLocationId));
             }
+          }
+
+          Optional<ReferenceLink> callNumberRL = migrationService.referenceLinkRepo.findByTypeIdAndExternalReference(holdingToCallNumberTypeId, holdingRL.get().getId());
+
+          if (callNumberRL.isPresent()) {
+            itemRecord.setCallNumber(callNumberRL.get().getFolioReference());
           }
 
           Optional<ReferenceLink> callNumberPrefixRL = migrationService.referenceLinkRepo.findByTypeIdAndExternalReference(holdingToCallNumberPrefixTypeId, holdingRL.get().getId());

--- a/src/main/java/org/folio/rest/migration/model/ItemRecord.java
+++ b/src/main/java/org/folio/rest/migration/model/ItemRecord.java
@@ -69,6 +69,8 @@ public class ItemRecord {
   private String createdByUserId;
   private Date createdDate;
 
+  private String callNumber;
+
   private String callNumberPrefix;
 
   private String callNumberSuffix;
@@ -226,6 +228,14 @@ public class ItemRecord {
     this.createdDate = createdDate;
   }
 
+  public String getCallNumber() {
+    return callNumber;
+  }
+
+  public void setCallNumber(String callNumber) {
+    this.callNumber = callNumber;
+  }
+
   public String getCallNumberPrefix() {
     return callNumberPrefix;
   }
@@ -356,7 +366,6 @@ public class ItemRecord {
 
 
     EffectiveCallNumberComponents effectiveCallNumberComponents = new EffectiveCallNumberComponents();
-    effectiveCallNumberComponents.setCallNumber(mfhdItem.getCallNumber());
 
     String callNumberType = mfhdItem.getCallNumberType();
     if (StringUtils.isNotEmpty(callNumberType) && maps.getCallNumberType().containsKey(callNumberType)) {
@@ -365,6 +374,7 @@ public class ItemRecord {
       effectiveCallNumberComponents.setTypeId(defaults.getCallNumberTypeId());
     }
 
+    effectiveCallNumberComponents.setCallNumber(callNumber);
     effectiveCallNumberComponents.setPrefix(callNumberPrefix);
     effectiveCallNumberComponents.setSuffix(callNumberSuffix);
 

--- a/src/main/resources/referenceLinkTypes/holdings/holdingToCallNumberAMDB.json
+++ b/src/main/resources/referenceLinkTypes/holdings/holdingToCallNumberAMDB.json
@@ -1,0 +1,4 @@
+{
+  "id": "0d9b3c6e-e486-4e8f-97c8-60995d46cfce",
+  "name": "HOLDING_TO_CALL_NUMBER_AMDB"
+}

--- a/src/main/resources/referenceLinkTypes/holdings/holdingToCallNumberMSDB.json
+++ b/src/main/resources/referenceLinkTypes/holdings/holdingToCallNumberMSDB.json
@@ -1,0 +1,4 @@
+{
+  "id": "2237564d-30f2-4529-9320-374221af44f1",
+  "name": "HOLDING_TO_CALL_NUMBER_MSDB"
+}


### PR DESCRIPTION
Use a new reference link to pass call number from holdings migration to items migration. The call number must come from MARC holdings.